### PR TITLE
Implement indicator position customization

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
@@ -52,7 +52,8 @@ import ir.ehsannarmani.compose_charts.models.BarProperties
 import ir.ehsannarmani.compose_charts.models.Bars
 import ir.ehsannarmani.compose_charts.models.DividerProperties
 import ir.ehsannarmani.compose_charts.models.GridProperties
-import ir.ehsannarmani.compose_charts.models.IndicatorProperties
+import ir.ehsannarmani.compose_charts.models.HorizontalIndicatorProperties
+import ir.ehsannarmani.compose_charts.models.IndicatorPosition
 import ir.ehsannarmani.compose_charts.models.LabelHelperProperties
 import ir.ehsannarmani.compose_charts.models.LabelProperties
 import ir.ehsannarmani.compose_charts.models.PopupProperties
@@ -75,7 +76,9 @@ fun ColumnChart(
         textStyle = TextStyle.Default,
         enabled = true
     ),
-    indicatorProperties: IndicatorProperties = IndicatorProperties(textStyle = TextStyle.Default),
+    indicatorProperties: HorizontalIndicatorProperties = HorizontalIndicatorProperties(
+        textStyle = TextStyle.Default
+    ),
     dividerProperties: DividerProperties = DividerProperties(),
     gridProperties: GridProperties = GridProperties(),
     labelHelperProperties: LabelHelperProperties = LabelHelperProperties(),
@@ -146,7 +149,7 @@ fun ColumnChart(
     }
 
     val xPadding = remember {
-        if (indicatorProperties.enabled && indicatorProperties.position == IndicatorProperties.Position.Start) {
+        if (indicatorProperties.enabled && indicatorProperties.position == IndicatorPosition.Horizontal.Start) {
             indicatorAreaWidth
         } else {
             0f
@@ -276,8 +279,8 @@ fun ColumnChart(
                                 style = indicatorProperties.textStyle
                             )
                         val x = when (indicatorProperties.position) {
-                            IndicatorProperties.Position.Start -> 0f
-                            IndicatorProperties.Position.End -> barsAreaWidth + 16 * density.density
+                            IndicatorPosition.Horizontal.Start -> 0f
+                            IndicatorPosition.Horizontal.End -> barsAreaWidth + 16 * density.density
                         }
                         drawText(
                             textLayoutResult = measureResult,
@@ -296,7 +299,7 @@ fun ColumnChart(
                     xPadding = xPadding,
                     size = size.copy(width = barsAreaWidth),
                     dividersProperties = dividerProperties,
-                    indicatorProperties = indicatorProperties,
+                    indicatorPosition = indicatorProperties.position,
                     xAxisProperties = gridProperties.xAxisProperties,
                     yAxisProperties = gridProperties.yAxisProperties,
                     gridEnabled = gridProperties.enabled
@@ -361,7 +364,7 @@ fun ColumnChart(
             Spacer(modifier = Modifier.height(labelProperties.padding))
 
             val widthModifier =
-                if (indicatorProperties.position == IndicatorProperties.Position.End) {
+                if (indicatorProperties.position == IndicatorPosition.Horizontal.End) {
                     Modifier.width((chartWidth.value / density.density).dp)
                 } else {
                     Modifier.fillMaxWidth()

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -37,14 +39,14 @@ import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.toSize
 import ir.ehsannarmani.compose_charts.components.RCChartLabelHelper
-import ir.ehsannarmani.compose_charts.extensions.MotionEvent
 import ir.ehsannarmani.compose_charts.extensions.addRoundRect
 import ir.ehsannarmani.compose_charts.extensions.drawGridLines
-import ir.ehsannarmani.compose_charts.extensions.pointerInteropFilter
 import ir.ehsannarmani.compose_charts.extensions.spaceBetween
 import ir.ehsannarmani.compose_charts.extensions.split
 import ir.ehsannarmani.compose_charts.models.AnimationMode
@@ -143,6 +145,18 @@ fun ColumnChart(
         } else {
             0f
         }
+    }
+
+    val xPadding = remember {
+        if (indicatorProperties.enabled && indicatorProperties.position == IndicatorProperties.Position.Start) {
+            indicatorAreaWidth
+        } else {
+            0f
+        }
+    }
+
+    val chartWidth = remember {
+        mutableFloatStateOf(0f)
     }
 
     LaunchedEffect(selectedValue.value) {
@@ -247,6 +261,7 @@ fun ColumnChart(
             ) {
 
                 val barsAreaWidth = size.width - (indicatorAreaWidth)
+                chartWidth.value = barsAreaWidth
                 val zeroY = size.height - calculateOffset(
                     maxValue = maxValue,
                     minValue = minValue,
@@ -262,10 +277,15 @@ fun ColumnChart(
                                 indicatorProperties.contentBuilder(indicator),
                                 style = indicatorProperties.textStyle
                             )
+                        val textWidth = measureResult.size.width
+                        val x = when (indicatorProperties.position) {
+                            IndicatorProperties.Position.Start -> 0f
+                            IndicatorProperties.Position.End -> size.width - textWidth
+                        }
                         drawText(
                             textLayoutResult = measureResult,
                             topLeft = Offset(
-                                x = 0f,
+                                x = x,
                                 y = (size.height - measureResult.size.height).spaceBetween(
                                     itemCount = indicators.count(),
                                     index
@@ -276,9 +296,10 @@ fun ColumnChart(
                 }
 
                 drawGridLines(
-                    xPadding = indicatorAreaWidth,
+                    xPadding = xPadding,
                     size = size.copy(width = barsAreaWidth),
                     dividersProperties = dividerProperties,
+                    indicatorProperties = indicatorProperties,
                     xAxisProperties = gridProperties.xAxisProperties,
                     yAxisProperties = gridProperties.yAxisProperties,
                     gridEnabled = gridProperties.enabled
@@ -293,12 +314,11 @@ fun ColumnChart(
                             ((col.value * size.height) / (maxValue - minValue)) * col.animator.value
                         val everyBarWidth = (stroke + spacing)
 
-
                         val barX =
                             (valueIndex * everyBarWidth) + (barsAreaWidth - everyDataWidth).spaceBetween(
                                 itemCount = data.count(),
                                 index = dataIndex
-                            ) + indicatorAreaWidth
+                            ) + xPadding
                         val rect = Rect(
                             offset = Offset(
                                 x = barX,
@@ -342,11 +362,18 @@ fun ColumnChart(
         }
         if (labelProperties.enabled) {
             Spacer(modifier = Modifier.height(labelProperties.padding))
+
+            val widthModifier =
+                if (indicatorProperties.position == IndicatorProperties.Position.End) {
+                    Modifier.width((chartWidth.value / density.density).dp)
+                } else {
+                    Modifier.fillMaxWidth()
+                }
+
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
+                modifier = widthModifier
                     .padding(
-                        start = (indicatorAreaWidth / density.density).dp,
+                        start = (xPadding / density.density).dp,
                     ), horizontalArrangement = Arrangement.SpaceBetween
             ) {
                 data.forEach {

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
@@ -39,8 +39,6 @@ import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.toSize
@@ -277,10 +275,9 @@ fun ColumnChart(
                                 indicatorProperties.contentBuilder(indicator),
                                 style = indicatorProperties.textStyle
                             )
-                        val textWidth = measureResult.size.width
                         val x = when (indicatorProperties.position) {
                             IndicatorProperties.Position.Start -> 0f
-                            IndicatorProperties.Position.End -> size.width - textWidth
+                            IndicatorProperties.Position.End -> barsAreaWidth + 16 * density.density
                         }
                         drawText(
                             textLayoutResult = measureResult,

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
@@ -46,6 +45,9 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.toSize
 import ir.ehsannarmani.compose_charts.components.LabelHelper
 import ir.ehsannarmani.compose_charts.extensions.drawGridLines
+import ir.ehsannarmani.compose_charts.extensions.line_chart.drawLineGradient
+import ir.ehsannarmani.compose_charts.extensions.line_chart.getLinePath
+import ir.ehsannarmani.compose_charts.extensions.line_chart.getPopupValue
 import ir.ehsannarmani.compose_charts.extensions.spaceBetween
 import ir.ehsannarmani.compose_charts.extensions.split
 import ir.ehsannarmani.compose_charts.models.AnimationMode
@@ -60,9 +62,6 @@ import ir.ehsannarmani.compose_charts.models.Line
 import ir.ehsannarmani.compose_charts.models.PopupProperties
 import ir.ehsannarmani.compose_charts.models.ZeroLineProperties
 import ir.ehsannarmani.compose_charts.utils.calculateOffset
-import ir.ehsannarmani.compose_charts.extensions.line_chart.drawLineGradient
-import ir.ehsannarmani.compose_charts.extensions.line_chart.getLinePath
-import ir.ehsannarmani.compose_charts.extensions.line_chart.getPopupValue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -449,15 +448,10 @@ private fun Indicator(
     minValue: Double,
     maxValue: Double
 ) {
-    val alignment = when (indicatorProperties.position) {
-        IndicatorProperties.Position.Start -> Alignment.Start
-        IndicatorProperties.Position.End -> Alignment.End
-    }
     Column(
         modifier = modifier
             .fillMaxHeight(),
-        verticalArrangement = Arrangement.SpaceBetween,
-        horizontalAlignment = alignment
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
         split(
             count = indicatorProperties.count,

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
@@ -227,27 +228,20 @@ fun LineChart(
             Spacer(modifier = Modifier.height(labelHelperPadding))
         }
         Row(modifier = Modifier.fillMaxSize()) {
+            val paddingBottom = (labelAreaHeight / density.density).dp
             if (indicatorProperties.enabled) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .padding(bottom = (labelAreaHeight / density.density).dp),
-                    verticalArrangement = Arrangement.SpaceBetween
-                ) {
-                    split(
-                        count = indicatorProperties.count,
+                if (indicatorProperties.position == IndicatorProperties.Position.Start) {
+                    Indicator(
+                        modifier = Modifier.padding(bottom = paddingBottom),
+                        indicatorProperties = indicatorProperties,
                         minValue = minValue,
                         maxValue = maxValue
-                    ).forEach {
-                        BasicText(
-                            text = indicatorProperties.contentBuilder(it),
-                            style = indicatorProperties.textStyle
-                        )
-                    }
+                    )
+                    Spacer(modifier = Modifier.width(18.dp))
                 }
-                Spacer(modifier = Modifier.width(18.dp))
             }
             Canvas(modifier = Modifier
+                .weight(1f)
                 .fillMaxSize()
                 .pointerInput(data) {
                     detectDragGestures(
@@ -340,6 +334,7 @@ fun LineChart(
 
                 drawGridLines(
                     dividersProperties = dividerProperties,
+                    indicatorProperties = indicatorProperties,
                     xAxisProperties = gridProperties.xAxisProperties,
                     yAxisProperties = gridProperties.yAxisProperties,
                     size = size.copy(height = chartAreaHeight),
@@ -432,10 +427,50 @@ fun LineChart(
                     )
                 }
             }
+            if (indicatorProperties.enabled) {
+                if (indicatorProperties.position == IndicatorProperties.Position.End) {
+                    Spacer(modifier = Modifier.width(18.dp))
+                    Indicator(
+                        modifier = Modifier.padding(bottom = paddingBottom),
+                        indicatorProperties = indicatorProperties,
+                        minValue = minValue,
+                        maxValue = maxValue
+                    )
+                }
+            }
         }
     }
 }
 
+@Composable
+private fun Indicator(
+    modifier: Modifier = Modifier,
+    indicatorProperties: IndicatorProperties,
+    minValue: Double,
+    maxValue: Double
+) {
+    val alignment = when (indicatorProperties.position) {
+        IndicatorProperties.Position.Start -> Alignment.Start
+        IndicatorProperties.Position.End -> Alignment.End
+    }
+    Column(
+        modifier = modifier
+            .fillMaxHeight(),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = alignment
+    ) {
+        split(
+            count = indicatorProperties.count,
+            minValue = minValue,
+            maxValue = maxValue
+        ).forEach {
+            BasicText(
+                text = indicatorProperties.contentBuilder(it),
+                style = indicatorProperties.textStyle
+            )
+        }
+    }
+}
 
 private fun DrawScope.drawPopup(
     popup: Popup,

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -55,7 +55,8 @@ import ir.ehsannarmani.compose_charts.models.DividerProperties
 import ir.ehsannarmani.compose_charts.models.DotProperties
 import ir.ehsannarmani.compose_charts.models.DrawStyle
 import ir.ehsannarmani.compose_charts.models.GridProperties
-import ir.ehsannarmani.compose_charts.models.IndicatorProperties
+import ir.ehsannarmani.compose_charts.models.HorizontalIndicatorProperties
+import ir.ehsannarmani.compose_charts.models.IndicatorPosition
 import ir.ehsannarmani.compose_charts.models.LabelHelperProperties
 import ir.ehsannarmani.compose_charts.models.LabelProperties
 import ir.ehsannarmani.compose_charts.models.Line
@@ -82,7 +83,9 @@ fun LineChart(
     dividerProperties: DividerProperties = DividerProperties(),
     gridProperties: GridProperties = GridProperties(),
     zeroLineProperties: ZeroLineProperties = ZeroLineProperties(),
-    indicatorProperties: IndicatorProperties = IndicatorProperties(textStyle = TextStyle.Default),
+    indicatorProperties: HorizontalIndicatorProperties = HorizontalIndicatorProperties(
+        textStyle = TextStyle.Default
+    ),
     labelHelperProperties: LabelHelperProperties = LabelHelperProperties(),
     labelHelperPadding: Dp = 26.dp,
     textMeasurer: TextMeasurer = rememberTextMeasurer(),
@@ -229,7 +232,7 @@ fun LineChart(
         Row(modifier = Modifier.fillMaxSize()) {
             val paddingBottom = (labelAreaHeight / density.density).dp
             if (indicatorProperties.enabled) {
-                if (indicatorProperties.position == IndicatorProperties.Position.Start) {
+                if (indicatorProperties.position == IndicatorPosition.Horizontal.Start) {
                     Indicator(
                         modifier = Modifier.padding(bottom = paddingBottom),
                         indicatorProperties = indicatorProperties,
@@ -252,13 +255,15 @@ fun LineChart(
                             }
                         },
                         onDrag = { change, amount ->
-                            val _size = size.toSize().copy(height = (size.height - labelAreaHeight).toFloat())
+                            val _size = size.toSize()
+                                .copy(height = (size.height - labelAreaHeight).toFloat())
                             popups.clear()
                             data.forEach {
                                 val properties = it.popupProperties ?: popupProperties
 
                                 if (properties.enabled) {
-                                    val positionX = (change.position.x).coerceIn(0f, size.width.toFloat())
+                                    val positionX =
+                                        (change.position.x).coerceIn(0f, size.width.toFloat())
                                     val fraction = (positionX / size.width)
                                     val popupValue = getPopupValue(
                                         points = it.values,
@@ -333,7 +338,7 @@ fun LineChart(
 
                 drawGridLines(
                     dividersProperties = dividerProperties,
-                    indicatorProperties = indicatorProperties,
+                    indicatorPosition = indicatorProperties.position,
                     xAxisProperties = gridProperties.xAxisProperties,
                     yAxisProperties = gridProperties.yAxisProperties,
                     size = size.copy(height = chartAreaHeight),
@@ -427,7 +432,7 @@ fun LineChart(
                 }
             }
             if (indicatorProperties.enabled) {
-                if (indicatorProperties.position == IndicatorProperties.Position.End) {
+                if (indicatorProperties.position == IndicatorPosition.Horizontal.End) {
                     Spacer(modifier = Modifier.width(18.dp))
                     Indicator(
                         modifier = Modifier.padding(bottom = paddingBottom),
@@ -444,7 +449,7 @@ fun LineChart(
 @Composable
 private fun Indicator(
     modifier: Modifier = Modifier,
-    indicatorProperties: IndicatorProperties,
+    indicatorProperties: HorizontalIndicatorProperties,
     minValue: Double,
     maxValue: Double
 ) {

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/GridLines.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/GridLines.kt
@@ -5,9 +5,11 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import ir.ehsannarmani.compose_charts.models.DividerProperties
 import ir.ehsannarmani.compose_charts.models.GridProperties
+import ir.ehsannarmani.compose_charts.models.IndicatorProperties
 
 fun DrawScope.drawGridLines(
     dividersProperties: DividerProperties,
+    indicatorProperties: IndicatorProperties = IndicatorProperties(position = IndicatorProperties.Position.Start),
     gridEnabled: Boolean,
     xAxisProperties: GridProperties.AxisProperties,
     yAxisProperties: GridProperties.AxisProperties,
@@ -46,10 +48,14 @@ fun DrawScope.drawGridLines(
         }
     }
     if (yAxisProperties.enabled && gridEnabled) {
+        val x = when (indicatorProperties.position) {
+            IndicatorProperties.Position.Start -> this.size.width
+            IndicatorProperties.Position.End -> 0f
+        }
         drawLine(
             brush = yAxisProperties.color,
-            start = Offset(this.size.width, 0f),
-            end = Offset(this.size.width, _size.height),
+            start = Offset(x, 0f),
+            end = Offset(x, _size.height),
             strokeWidth = yAxisProperties.thickness.toPx(),
             pathEffect = yAxisPathEffect
         )
@@ -64,10 +70,14 @@ fun DrawScope.drawGridLines(
         )
     }
     if (dividersProperties.yAxisProperties.enabled && dividersProperties.enabled) {
+        val x = when (indicatorProperties.position) {
+            IndicatorProperties.Position.Start -> 0f
+            IndicatorProperties.Position.End -> _size.width
+        }
         drawLine(
             brush = dividersProperties.yAxisProperties.color,
-            start = Offset(0f + xPadding, 0f),
-            end = Offset(0f + xPadding, _size.height),
+            start = Offset(x + xPadding, 0f),
+            end = Offset(x + xPadding, _size.height),
             strokeWidth = dividersProperties.yAxisProperties.thickness.toPx(),
             pathEffect = dividersProperties.yAxisProperties.style.pathEffect
         )

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/GridLines.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/GridLines.kt
@@ -5,16 +5,17 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import ir.ehsannarmani.compose_charts.models.DividerProperties
 import ir.ehsannarmani.compose_charts.models.GridProperties
-import ir.ehsannarmani.compose_charts.models.IndicatorProperties
+import ir.ehsannarmani.compose_charts.models.IndicatorPosition
 
 fun DrawScope.drawGridLines(
     dividersProperties: DividerProperties,
-    indicatorProperties: IndicatorProperties = IndicatorProperties(position = IndicatorProperties.Position.Start),
+    indicatorPosition: IndicatorPosition,
     gridEnabled: Boolean,
     xAxisProperties: GridProperties.AxisProperties,
     yAxisProperties: GridProperties.AxisProperties,
     size: Size? = null,
     xPadding: Float = 0f,
+    yPadding: Float = 0f
 ) {
 
     val _size = size ?: this.size
@@ -24,60 +25,45 @@ fun DrawScope.drawGridLines(
 
 
     if (xAxisProperties.enabled && gridEnabled) {
-        for (i in 0 until xAxisProperties.lineCount - 1) {
+        for (i in 0 until xAxisProperties.lineCount) {
             val y = _size.height.spaceBetween(itemCount = xAxisProperties.lineCount, index = i)
             drawLine(
                 brush = xAxisProperties.color,
-                start = Offset(0f + xPadding, y),
-                end = Offset(_size.width + xPadding, y),
+                start = Offset(0f + xPadding, y + yPadding),
+                end = Offset(_size.width + xPadding, y + yPadding),
                 strokeWidth = xAxisProperties.thickness.toPx(),
                 pathEffect = xAxisPathEffect
             )
         }
     }
     if (yAxisProperties.enabled && gridEnabled) {
-        for (i in 1 until yAxisProperties.lineCount) {
+        for (i in 0 until yAxisProperties.lineCount) {
             val x = _size.width.spaceBetween(itemCount = yAxisProperties.lineCount, index = i)
             drawLine(
                 brush = xAxisProperties.color,
-                start = Offset(x + xPadding, 0f),
-                end = Offset(x + xPadding, _size.height),
+                start = Offset(x + xPadding, 0f + yPadding),
+                end = Offset(x + xPadding, _size.height + yPadding),
                 strokeWidth = xAxisProperties.thickness.toPx(),
                 pathEffect = yAxisPathEffect
             )
         }
     }
-    if (yAxisProperties.enabled && gridEnabled) {
-        val x = when (indicatorProperties.position) {
-            IndicatorProperties.Position.Start -> this.size.width
-            IndicatorProperties.Position.End -> 0f
-        }
-        drawLine(
-            brush = yAxisProperties.color,
-            start = Offset(x, 0f),
-            end = Offset(x, _size.height),
-            strokeWidth = yAxisProperties.thickness.toPx(),
-            pathEffect = yAxisPathEffect
-        )
-    }
     if (dividersProperties.xAxisProperties.enabled && dividersProperties.enabled) {
+        val y = if (indicatorPosition == IndicatorPosition.Vertical.Top) 0f else _size.height
         drawLine(
             brush = dividersProperties.xAxisProperties.color,
-            start = Offset(0f + xPadding, _size.height),
-            end = Offset(_size.width + xPadding, _size.height),
+            start = Offset(0f + xPadding, y + yPadding),
+            end = Offset(_size.width + xPadding, y + yPadding),
             strokeWidth = dividersProperties.xAxisProperties.thickness.toPx(),
             pathEffect = dividersProperties.xAxisProperties.style.pathEffect
         )
     }
     if (dividersProperties.yAxisProperties.enabled && dividersProperties.enabled) {
-        val x = when (indicatorProperties.position) {
-            IndicatorProperties.Position.Start -> 0f
-            IndicatorProperties.Position.End -> _size.width
-        }
+        val x = if (indicatorPosition == IndicatorPosition.Horizontal.End)  _size.width else  0f
         drawLine(
             brush = dividersProperties.yAxisProperties.color,
-            start = Offset(x + xPadding, 0f),
-            end = Offset(x + xPadding, _size.height),
+            start = Offset(x + xPadding, 0f + yPadding),
+            end = Offset(x + xPadding, _size.height + yPadding),
             strokeWidth = dividersProperties.yAxisProperties.thickness.toPx(),
             pathEffect = dividersProperties.yAxisProperties.style.pathEffect
         )

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/IndicatorProperties.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/IndicatorProperties.kt
@@ -8,7 +8,13 @@ data class IndicatorProperties(
     val enabled:Boolean = true,
     val textStyle: TextStyle = TextStyle.Default.copy(fontSize = 12.sp),
     val count: Int = 5,
+    val position: Position = Position.Start,
     val contentBuilder: (Double) -> String = {
         it.format(1)
-    },
-)
+    }
+) {
+    enum class Position {
+        Start,
+        End
+    }
+}

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/IndicatorProperties.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/IndicatorProperties.kt
@@ -4,16 +4,53 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.sp
 import ir.ehsannarmani.compose_charts.extensions.format
 
-data class IndicatorProperties(
-    val enabled:Boolean = true,
-    val textStyle: TextStyle = TextStyle.Default.copy(fontSize = 12.sp),
-    val count: Int = 5,
-    val position: Position = Position.Start,
-    val contentBuilder: (Double) -> String = {
+sealed class IndicatorProperties(
+    open val enabled:Boolean,
+    open val textStyle: TextStyle,
+    open val count: Int,
+    open val position: IndicatorPosition,
+    open val contentBuilder: (Double) -> String
+)
+
+
+data class VerticalIndicatorProperties(
+    override val enabled: Boolean = true,
+    override val textStyle: TextStyle = TextStyle.Default.copy(fontSize = 12.sp),
+    override val count: Int = 5,
+    override val position: IndicatorPosition.Vertical = IndicatorPosition.Vertical.Bottom,
+    override val contentBuilder: (Double) -> String = {
         it.format(1)
     }
-) {
-    enum class Position {
+) : IndicatorProperties(
+    enabled = enabled,
+    textStyle = textStyle,
+    count = count,
+    position = position,
+    contentBuilder = contentBuilder
+)
+
+data class HorizontalIndicatorProperties(
+    override val enabled: Boolean = true,
+    override val textStyle: TextStyle = TextStyle.Default.copy(fontSize = 12.sp),
+    override val count: Int = 5,
+    override val position: IndicatorPosition.Horizontal = IndicatorPosition.Horizontal.Start,
+    override val contentBuilder: (Double) -> String = {
+        it.format(1)
+    }
+) : IndicatorProperties(
+    enabled = enabled,
+    textStyle = textStyle,
+    count = count,
+    position = position,
+    contentBuilder = contentBuilder
+)
+
+sealed interface IndicatorPosition {
+    enum class Vertical : IndicatorPosition {
+        Top,
+        Bottom
+    }
+    enum class Horizontal: IndicatorPosition {
         Start,
         End
     }


### PR DESCRIPTION
In this issue #11, I have requested a feature to position the indicators to the start or end of the chart for the line and column charts. 

Edit: Now also included RowCharts.

### Samples
> [!TIP]
> For old implementations that wanted to retain the position at the start, there is nothing to do as change defaults to the start position.

**Column Chart**
```kotlin
ColumnChart(
    ...,
    indicatorProperties = IndicatorProperties(
        textStyle = TextStyle(fontSize = 12.sp, fontFamily = ubuntu, color = Color.White),
        count = 4,
        position = IndicatorProperties.Position.End // Define the position, defaults to Start
    ),
    ...
)
``` 

<img src="https://github.com/ehsannarmani/ComposeCharts/assets/113887292/ea2d04c2-d5b8-4b4c-9f75-06fab7b422e2" alt="Column Chart with indicator positioned at the end" width="300">

**Line Chart**
```kotlin
LineChart(
    ...,
    indicatorProperties = IndicatorProperties(
        textStyle = TextStyle(fontSize = 12.sp, fontFamily = ubuntu, color = Color.White),
        count = 4,
        position = IndicatorProperties.Position.End // Define the position, defaults to Start
    ),
    ...
)
``` 

<img src="https://github.com/ehsannarmani/ComposeCharts/assets/113887292/2711e194-8ee3-4a9f-a99b-422732643197" alt="Column Chart with indicator positioned at the end" width="300">


> [!NOTE]
> I only implemented the implementation. I would like to relay the documentation update (README) to the maintainers/owner for uniformity if this ever gets merged.

Thank you!