### PR TITLE
Helper label fix for small screens

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/components/LabelHelper.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/components/LabelHelper.kt
@@ -19,16 +19,19 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import ir.ehsannarmani.compose_charts.models.Bars
+import kotlin.math.min
 
 @Composable
 fun LabelHelper(
     data: List<Pair<String, Brush>>,
     textStyle: TextStyle = TextStyle.Default.copy(fontSize = 13.sp)
 ) {
-    LazyVerticalGrid(columns = GridCells.Fixed(3), modifier = Modifier) {
+    val numberOfGridCells = min(data.size, 3)
+    LazyVerticalGrid(columns = GridCells.Fixed(numberOfGridCells), modifier = Modifier) {
         items(data) { (label, color) ->
             Row(
                 modifier = Modifier
@@ -42,7 +45,12 @@ fun LabelHelper(
                         .clip(CircleShape)
                         .background(color)
                 )
-                BasicText(text = label, style = textStyle)
+                BasicText(
+                    text = label,
+                    style = textStyle,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }
@@ -53,8 +61,8 @@ fun LabelHelper(
  */
 @Composable
 fun RCChartLabelHelper(
-    data:List<Bars>,
-    textStyle: TextStyle =  TextStyle.Default.copy(fontSize = 13.sp)
+    data: List<Bars>,
+    textStyle: TextStyle = TextStyle.Default.copy(fontSize = 13.sp)
 ) {
     val labels = data.flatMap { it.values.map { it.label } }.distinct()
     val colors = labels.map { label ->


### PR DESCRIPTION
Added fix for helper label in bar and line charts when the screen size is small.

Issue #45 will be fixed with this.

Screenshot after fix:
<img src="https://github.com/user-attachments/assets/aa8ee200-32d5-47f8-b548-2e92fe101589" alt="Test Screenshot for label adjustment" width="300">

