### PR TITLE
Fix uncorrect incorrect chart section detected in pie chart

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/Circle.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/Circle.kt
@@ -1,0 +1,13 @@
+package ir.ehsannarmani.compose_charts.extensions
+
+import androidx.compose.ui.geometry.Offset
+import kotlin.math.pow
+
+fun isInsideCircle(touchTapOffset: Offset, pieceOffset: Offset, radius: Float): Boolean {
+    // Calculate the squared distance between the touch point and the circle's center
+    val distanceSquared =
+        (touchTapOffset.x - pieceOffset.x).pow(2) + (touchTapOffset.y - pieceOffset.y).pow(2)
+
+    // Compare the squared distance with the squared radius to avoid using sqrt (more efficient)
+    return distanceSquared <= radius.pow(2)
+}

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/Degree.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/Degree.kt
@@ -1,0 +1,40 @@
+package ir.ehsannarmani.compose_charts.extensions
+
+import androidx.compose.ui.geometry.Offset
+import ir.ehsannarmani.compose_charts.models.Vector
+import kotlin.math.PI
+import kotlin.math.acos
+import kotlin.math.pow
+import kotlin.math.sqrt
+
+fun getAngleInDegree(touchTapOffset: Offset, pieceOffset: Offset): Float {
+
+    // Create vectors: u (from piece to tap point) and v (reference vector along x-axis)
+    val u = Vector(touchTapOffset.x - pieceOffset.x, touchTapOffset.y - pieceOffset.y)
+
+    // Reference vector along the positive x-axis
+    val v = Vector(1f, 0f)
+
+    // Compute the dot product of vectors u and v
+    val dotProduct = u.x * v.x + u.y * v.y
+
+    // Compute the magnitudes of vectors u and v
+    val magnitudeU = sqrt(u.x.pow(2) + u.y.pow(2))
+    val magnitudeV = sqrt(v.x.pow(2) + v.y.pow(2))
+
+    // Calculate the angle in radians using the dot product formula
+    val angleInRadians = acos(dotProduct / (magnitudeU * magnitudeV))
+
+    // Convert the angle from radians to degrees
+    // Adjust the angle based on the y-direction to get the correct orientation
+    val angleInDegrees = if ((touchTapOffset.y - pieceOffset.y) > 0) {
+        angleInRadians * (180 / PI)
+    } else {
+        360 - angleInRadians * (180 / PI)
+    }
+    return angleInDegrees.toFloat()
+}
+
+fun isDegreeBetween(target: Float, start: Float, end: Float): Boolean {
+    return target in start..end
+}

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/Vector.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/Vector.kt
@@ -1,0 +1,6 @@
+package ir.ehsannarmani.compose_charts.models
+
+data class Vector(
+    val x: Float,
+    val y: Float
+)


### PR DESCRIPTION
related to #69 

The conditions for determining whether a touch point corresponds to a pie piece have been updated to satisfy both of the following:

1. Check if the touch point's angle falls within the pie's sector

- Compute the angle using the dot product between the positive x-axis vector and the vector from the circle center to the touch point.
- Verify whether `startFromDegree < degree < endToDegree`.

2. Check if the touch point is inside the overall pie chart

- Ensure that `𝑥 * 𝑥 + 𝑦 * y ≤ radius * radius`, confirming that the point lies within the circular boundary.

https://github.com/user-attachments/assets/cf6302cc-203c-49b4-8f24-19f3670ef89c

