### PR TITLE
Improvement/Replace the onTap gesture from the LineChart with onPress

### DIFF
--- a/compose-charts/build.gradle.kts
+++ b/compose-charts/build.gradle.kts
@@ -15,7 +15,7 @@ mavenPublishing{
     coordinates(
         groupId = "io.github.ehsannarmani",
         artifactId = "compose-charts",
-        version = "0.1.8"
+        version = "0.1.9"
     )
     pom{
         name.set("Compose Charts")


### PR DESCRIPTION
Replace the onTap gesture from the LineChart with onPress to keep the pop-up visible until the release event
Update the show pop-up animation to use the popupProperties object
Keep the pop-up on the chart based on the duration attribute from the popupProperties object