### PR TITLE
feat: Make PopupProperties.contentBuilder allow for null

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
@@ -400,6 +400,9 @@ private fun DrawScope.drawPopup(
     textMeasurer: TextMeasurer,
     progress: Float,
 ) {
+    if (!properties.confirmDraw(selectedBar.dataIndex, selectedBar.valueIndex, selectedBar.bar.value))
+        return
+
     val measure = textMeasurer.measure(
         properties.contentBuilder(selectedBar.dataIndex, selectedBar.valueIndex, selectedBar.bar.value),
         style = properties.textStyle.copy(

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -614,8 +614,11 @@ private fun DrawScope.drawPopup(
     progress: Float,
     offsetAnimator: Pair<Animatable<Float, AnimationVector1D>, Animatable<Float, AnimationVector1D>>? = null
 ) {
-    val offset = popup.position
     val popupProperties = popup.properties
+    if (!popupProperties.confirmDraw(popup.dataIndex, popup.valueIndex, popup.value))
+        return
+
+    val offset = popup.position
     val measureResult = textMeasurer.measure(
         popupProperties.contentBuilder(popup.dataIndex, popup.valueIndex, popup.value),
         style = popupProperties.textStyle.copy(

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/RowChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/RowChart.kt
@@ -394,6 +394,9 @@ private fun DrawScope.drawPopUp(
     textMeasurer: TextMeasurer,
     progress: Float,
 ) {
+    if (!properties.confirmDraw(selectedBar.dataIndex, selectedBar.valueIndex, selectedBar.bar.value))
+        return
+
     val measure = textMeasurer.measure(
         properties.contentBuilder(selectedBar.dataIndex, selectedBar.valueIndex, selectedBar.bar.value),
         style = properties.textStyle.copy(

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/PopupProperties.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/PopupProperties.kt
@@ -21,6 +21,9 @@ data class PopupProperties(
     val mode: Mode = Mode.Normal,
     val contentBuilder: (dataIndex: Int, valueIndex: Int, value: Double) -> String = { dataIndex, valueIndex, value ->
         value.format(1)
+    },
+    val confirmDraw: (dataIndex: Int, valueIndex: Int, value: Double) -> Boolean = { dataIndex, valueIndex, value ->
+        true
     }
 ) {
     sealed class Mode {


### PR DESCRIPTION
- fixes #133

Example where I return null on odd indexes

![output](https://github.com/user-attachments/assets/db252e0d-14a9-4c40-976a-39194bf5b21e)
