### PR TITLE
feat: Ability to specify what dots should be drawn

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -520,9 +520,14 @@ fun LineChart(
                         if ((line.dotProperties?.enabled ?: dotsProperties.enabled)) {
                             drawDots(
                                 dataPoints = line.values.mapIndexed { mapIndex, value ->
-                                    (dotAnimators.getOrNull(
-                                        index
-                                    )?.getOrNull(mapIndex) ?: Animatable(0f)) to value.toFloat()
+                                    Triple(
+                                        first = dotAnimators
+                                            .getOrNull(index)
+                                            ?.getOrNull(mapIndex)
+                                            ?: Animatable(0f),
+                                        second = value.toFloat(),
+                                        third = index
+                                    )
                                 },
                                 properties = line.dotProperties ?: dotsProperties,
                                 linePath = segmentedPath,
@@ -710,7 +715,7 @@ private fun DrawScope.drawPopup(
 }
 
 fun DrawScope.drawDots(
-    dataPoints: List<Pair<Animatable<Float, AnimationVector1D>, Float>>,
+    dataPoints: List<Triple<Animatable<Float, AnimationVector1D>, Float, Int>>,
     properties: DotProperties,
     linePath: Path,
     maxValue: Float,
@@ -728,7 +733,10 @@ fun DrawScope.drawDots(
     pathMeasure.setPath(linePath, false)
     val lastPosition = pathMeasure.getPosition(pathMeasure.length)
     dataPoints.forEachIndexed { valueIndex, value ->
-        if (valueIndex in startIndex..endIndex) {
+        if (
+            properties.confirmDraw(value.third, valueIndex, value.second.toDouble()) &&
+            valueIndex in startIndex..endIndex
+        ) {
             val dotOffset = Offset(
                 x = _size.width.spaceBetween(
                     itemCount = dataPoints.count(),

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/DotProperties.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/models/DotProperties.kt
@@ -16,5 +16,8 @@ data class DotProperties(
     val strokeColor: Brush = SolidColor(Color.Unspecified),
     val strokeStyle: StrokeStyle = StrokeStyle.Normal,
     val animationEnabled:Boolean = true,
-    val animationSpec: AnimationSpec<Float> = tween(300)
+    val animationSpec: AnimationSpec<Float> = tween(300),
+    val confirmDraw: (dataIndex: Int, valueIndex: Int, value: Double) -> Boolean = { dataIndex, valueIndex, value ->
+        true
+    }
 )


### PR DESCRIPTION
- fixes #138


Example:
<img width="307" height="171" alt="image" src="https://github.com/user-attachments/assets/7495bee6-cd3b-4a00-b813-cac78564ea0f" />
