### PR TITLE
Ensure click listener updates are picked up

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/PieChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/PieChart.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -53,6 +54,7 @@ fun PieChart(
         "Data must be at least 0"
     }
 
+    val onPieClick by rememberUpdatedState(onPieClick)
     val scope = rememberCoroutineScope()
 
     var pieChartCenter by remember {

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/RowChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/RowChart.kt
@@ -13,11 +13,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
@@ -102,6 +104,8 @@ fun RowChart(
     checkRCMinValue(minValue, data)
     checkRCMaxValue(maxValue, data)
 
+    val onBarClick by rememberUpdatedState(onBarClick)
+    val onBarLongClick by rememberUpdatedState(onBarLongClick)
     val scope = rememberCoroutineScope()
     val density = LocalDensity.current
 


### PR DESCRIPTION
Prior to this change, listeners would not see updated state values when called multiple times.

```
@Composable
fun MyChart(foo: Int) {
  ColumnChart(
    ...
    onBarClick = { println(foo) }
  )
}

var foo by remember { mutableStateOf(1) }
MyChart(foo)
```

Currently, clicking will always print the same value, even though the ColumnChart is recomposed when foo is updated.