### PR TITLE
fix chart on resize

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -129,9 +129,9 @@ fun LineChart(
     val density = LocalDensity.current
     val scope = rememberCoroutineScope()
 
-    var chartSize by remember { mutableStateOf(Size(0f, 0f)) }
+    var chartSize by remember(density) { mutableStateOf(Size(0f, 0f)) }
 
-    val pathMeasure = remember(chartSize, density) {
+    val pathMeasure = remember(chartSize) {
         PathMeasure()
     }
 


### PR DESCRIPTION
this fixes the line chart on resize (probably has a minor conflict with the animation disabling PR)

while working on this, I realized that OneByOne mode could de-sync between line and gradient animations, so I combined the loops and launched the gradient animation at the start of the line animation.