### PR TITLE
fix ios line gradient crash and LineChart popup IOOBE

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -264,8 +264,11 @@ fun LineChart(
             val properties = line.popupProperties ?: popupProperties
             if (!properties.enabled) return@forEachIndexed
 
+            if (line.values.isEmpty()) return@forEachIndexed
+            val pathData = linesPathData.getOrNull(dataIndex) ?: return@forEachIndexed
+            if (pathData.xPositions.isEmpty()) return@forEachIndexed
+
             val positionX = position.x.coerceIn(0f, size.width.toFloat())
-            val pathData = linesPathData[dataIndex]
 
             val isSingleValue =  line.values.count() == 1
 

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/line_chart/Gradient.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/line_chart/Gradient.kt
@@ -1,10 +1,11 @@
 package ir.ehsannarmani.compose_charts.extensions.line_chart
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.*
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.drawscope.DrawScope
-import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 
 internal fun DrawScope.drawLineGradient(
     path: Path,
@@ -13,25 +14,25 @@ internal fun DrawScope.drawLineGradient(
     progress: Float,
     size: Size? = null,
     startOffset: Float,
-    endOffset: Float
+    endOffset: Float,
 ) {
     val _size = size ?: this.size
-    drawIntoCanvas {
-        val p = Path()
-        p.addPath(path)
-        p.lineTo(endOffset, _size.height)
-        p.lineTo(startOffset, _size.height)
-        p.close()
-        val paint = Paint()
-        paint.shader = LinearGradientShader(
-            Offset(0f, 0f),
-            Offset(0f, _size.height),
-            listOf(
+    val filled = Path().apply {
+        addPath(path)
+        lineTo(endOffset, _size.height)
+        lineTo(startOffset, _size.height)
+        close()
+    }
+    drawPath(
+        path = filled,
+        brush = Brush.verticalGradient(
+            colors = listOf(
                 color1.copy(alpha = color1.alpha * progress),
                 color2.copy(alpha = color2.alpha * progress),
             ),
-            tileMode = TileMode.Mirror
-        )
-        it.drawPath(p, paint)
-    }
+            startY = 0f,
+            endY = _size.height,
+            tileMode = TileMode.Mirror,
+        ),
+    )
 }


### PR DESCRIPTION
Two independent fixes in `LineChart`, kept as separate commits so they can be reviewed and reverted independently.

### 1. iOS `ClassCastException` in `drawLineGradient` on CMP 1.11.0 (closes #167)

`Gradient.kt` was using the low-level Skia interop path: `Paint().shader = LinearGradientShader(...)` inside `drawIntoCanvas { it.drawPath(p, paint) }`. In CMP <= 1.10 the iOS native bridge happened to unwrap this, but CMP 1.11.0 changed the internal `Shader` representation, so the runtime downcast in the iOS `paint.shader` setter fails:

```
kotlin.ClassCastException: class androidx.compose.ui.graphics.Shader
  cannot be cast to class org.jetbrains.skia.Shader
  at kfun:...drawLineGradient + 1995
```

Fix: use the public, multiplatform-safe `DrawScope.drawPath(path, brush)` with `Brush.verticalGradient`. The original gradient was strictly vertical (`Offset(0f, 0f)` to `Offset(0f, _size.height)`), so the swap is 1:1 and removes the `drawIntoCanvas` escape hatch entirely. Function signature is unchanged, both call sites in `LineChart.kt` keep compiling.

### 2. `LineChart.showPopup` IOOBE on empty / stale line data (closes #146, closes #158)

`showPopup` read `linesPathData[dataIndex]` and `xPositions[startIndex]` without guarding against three cases:

1. A `Line` whose `values` list is empty produces empty `xPositions`; the index access throws `IndexOutOfBoundsException`.
2. `LaunchedEffect(data, minValue, computedMaxValue) { linesPathData.clear() }` empties the state list whenever data updates, but a pointer event mid-update still tries to read `linesPathData[dataIndex]`, surfacing as `SnapshotStateList.get` IOOBE on the gesture thread. This is exactly the stack in #158.
3. `xPositions` empty even when `pathData` is present.

Three early-return guards added before the index access. Each fails this iteration only, so a malformed line does not poison a sibling line.

### Local build verification

```
./gradlew :compose-charts:compileKotlinIosArm64 \
          :compose-charts:compileKotlinIosSimulatorArm64 \
          :compose-charts:compileKotlinIosX64 \
          :compose-charts:compileKotlinDesktop
BUILD SUCCESSFUL
```

No new warnings introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gradient rendering for filled line charts.
  * Ensured gradient opacity responds correctly to chart progress.
  * Maintained the existing filled-area shape while improving drawing consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->