### PR TITLE
fix: prevent LineChart crash when popup path data is empty

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -258,16 +258,21 @@ fun LineChart(
         size: IntSize,
         position: Offset
     ) {
+        if (data.isEmpty() || linesPathData.isEmpty() || linesPathData.size != data.size) {
+            return
+        }
+
         popups.clear()
 
         data.forEachIndexed { dataIndex, line ->
             val properties = line.popupProperties ?: popupProperties
             if (!properties.enabled) return@forEachIndexed
+            if (line.values.isEmpty()) return@forEachIndexed
 
             val positionX = position.x.coerceIn(0f, size.width.toFloat())
-            val pathData = linesPathData[dataIndex]
+            val pathData = linesPathData.getOrNull(dataIndex) ?: return@forEachIndexed
 
-            val isSingleValue =  line.values.count() == 1
+            val isSingleValue = line.values.count() == 1
 
             if (
                 positionX >= pathData.xPositions[pathData.startIndex] &&
@@ -385,6 +390,7 @@ fun LineChart(
                         .pointerInput(data, minValue, computedMaxValue, linesPathData) {
                             if (!popupProperties.enabled || data.all { it.popupProperties?.enabled == false })
                                 return@pointerInput
+                            if (data.isEmpty() || linesPathData.isEmpty()) return@pointerInput
 
                             detectHorizontalDragGestures(
                                 onDragEnd = {
@@ -401,9 +407,10 @@ fun LineChart(
                                 }
                             )
                         }
-                        .pointerInput(Unit) {
+                        .pointerInput(data, minValue, computedMaxValue, linesPathData) {
                             if (!popupProperties.enabled || data.all { it.popupProperties?.enabled == false })
                                 return@pointerInput
+                            if (data.isEmpty() || linesPathData.isEmpty()) return@pointerInput
 
                             detectTapGestures(
                                 onPress = {


### PR DESCRIPTION
## Summary

- Guard `showPopup` against empty `data`, empty `linesPathData`, and size mismatches between them
- Use safe `getOrNull` access when reading path data per line index
- Skip popup pointer input when data or path data is not ready yet
- Update tap gesture `pointerInput` keys so handlers rebind when chart data changes

This prevents `IndexOutOfBoundsException` when interacting with a `LineChart` before path data is populated, or when the chart has no data.

Fixes #146
Fixes #158
Fixes #114

## Test plan

- [x] Build `:compose-charts:compileDebugKotlinAndroid` locally
- [ ] Render `LineChart` with an empty `data` list and drag/tap on the chart — no crash
- [ ] Render `LineChart` with valid data and verify popup drag/tap still works
- [ ] Toggle chart data from non-empty to empty while popup gestures are enabled — no crash