### PR TITLE
feat: add ZeroLineProperties support to ColumnChart and RowChart

### DIFF
--- a/app/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ui/RowSample.kt
+++ b/app/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ui/RowSample.kt
@@ -33,6 +33,7 @@ import ir.ehsannarmani.compose_charts.models.LabelHelperProperties
 import ir.ehsannarmani.compose_charts.models.LabelProperties
 import ir.ehsannarmani.compose_charts.models.PopupProperties
 import ir.ehsannarmani.compose_charts.models.VerticalIndicatorProperties
+import ir.ehsannarmani.compose_charts.models.ZeroLineProperties
 
 val rowGridProperties = GridProperties(
     enabled = true,
@@ -428,7 +429,12 @@ fun RowSample3(modifier: Modifier=Modifier) {
                     containerColor = Color(0xff414141),
                 ),
                 minValue = -75.0,
-                maxValue = 75.0
+                maxValue = 75.0,
+                zeroLineProperties = ZeroLineProperties(
+                    enabled = true,
+                    color = SolidColor(Color(0xFFAD1457)),
+                    thickness = 1.dp,
+                ),
             )
         }
     }

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/ColumnChart.kt
@@ -58,6 +58,7 @@ import ir.ehsannarmani.compose_charts.models.LabelHelperProperties
 import ir.ehsannarmani.compose_charts.models.LabelProperties
 import ir.ehsannarmani.compose_charts.models.PopupProperties
 import ir.ehsannarmani.compose_charts.models.SelectedBar
+import ir.ehsannarmani.compose_charts.models.ZeroLineProperties
 import ir.ehsannarmani.compose_charts.models.asRadiusPx
 import ir.ehsannarmani.compose_charts.utils.HorizontalLabels
 import ir.ehsannarmani.compose_charts.utils.ImplementRCAnimation
@@ -84,6 +85,7 @@ fun ColumnChart(
         textStyle = TextStyle.Default
     ),
     dividerProperties: DividerProperties = DividerProperties(),
+    zeroLineProperties: ZeroLineProperties = ZeroLineProperties(),
     gridProperties: GridProperties = GridProperties(),
     labelHelperProperties: LabelHelperProperties = LabelHelperProperties(),
     animationMode: AnimationMode = AnimationMode.Together { it * 200L },
@@ -132,6 +134,17 @@ fun ColumnChart(
 
     val popupAnimation = remember {
         Animatable(0f)
+    }
+
+    val zeroLineAnimation = remember(data) {
+        Animatable(0f)
+    }
+
+    LaunchedEffect(data, zeroLineProperties.enabled) {
+        if (zeroLineProperties.enabled) {
+            zeroLineAnimation.snapTo(0f)
+            zeroLineAnimation.animateTo(1f, animationSpec = zeroLineProperties.animationSpec)
+        }
     }
 
     val computedMaxValue =
@@ -319,6 +332,22 @@ fun ColumnChart(
                         gridEnabled = gridProperties.enabled
                     )
 
+                    val drawZeroLine = {
+                        drawLine(
+                            brush = zeroLineProperties.color,
+                            start = Offset(x = xPadding, y = zeroY),
+                            end = Offset(
+                                x = xPadding + barsAreaWidth * zeroLineAnimation.value,
+                                y = zeroY
+                            ),
+                            pathEffect = zeroLineProperties.style.pathEffect,
+                            strokeWidth = zeroLineProperties.thickness.toPx()
+                        )
+                    }
+                    if (zeroLineProperties.enabled && zeroLineProperties.zType == ZeroLineProperties.ZType.Under) {
+                        drawZeroLine()
+                    }
+
                     data.forEachIndexed { dataIndex, columnChart ->
                         columnChart.values.forEachIndexed { valueIndex, col ->
                             if (col.value != 0.0) {
@@ -372,6 +401,9 @@ fun ColumnChart(
                                 )
                             }
                         }
+                    }
+                    if (zeroLineProperties.enabled && zeroLineProperties.zType == ZeroLineProperties.ZType.Above) {
+                        drawZeroLine()
                     }
                     selectedValue.value?.let { selectedValue ->
                         drawPopup(

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/RowChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/RowChart.kt
@@ -60,6 +60,7 @@ import ir.ehsannarmani.compose_charts.models.LabelProperties
 import ir.ehsannarmani.compose_charts.models.PopupProperties
 import ir.ehsannarmani.compose_charts.models.SelectedBar
 import ir.ehsannarmani.compose_charts.models.VerticalIndicatorProperties
+import ir.ehsannarmani.compose_charts.models.ZeroLineProperties
 import ir.ehsannarmani.compose_charts.models.asRadiusPx
 import ir.ehsannarmani.compose_charts.utils.ImplementRCAnimation
 import ir.ehsannarmani.compose_charts.utils.VerticalLabels
@@ -86,6 +87,7 @@ fun RowChart(
     indicatorProperties: VerticalIndicatorProperties = VerticalIndicatorProperties(textStyle = TextStyle.Default),
     labelHelperProperties: LabelHelperProperties = LabelHelperProperties(),
     dividerProperties: DividerProperties = DividerProperties(),
+    zeroLineProperties: ZeroLineProperties = ZeroLineProperties(),
     gridProperties: GridProperties = GridProperties(),
     animationMode: AnimationMode = AnimationMode.Together { it * 200L },
     animationSpec: AnimationSpec<Float> = tween(500),
@@ -133,6 +135,17 @@ fun RowChart(
 
     val popupAnimation = remember {
         Animatable(0f)
+    }
+
+    val zeroLineAnimation = remember(data) {
+        Animatable(0f)
+    }
+
+    LaunchedEffect(data, zeroLineProperties.enabled) {
+        if (zeroLineProperties.enabled) {
+            zeroLineAnimation.snapTo(0f)
+            zeroLineAnimation.animateTo(1f, animationSpec = zeroLineProperties.animationSpec)
+        }
     }
 
     val computedMaxValue = rememberComputedChartMaxValue(minValue, maxValue, indicatorProperties.count)
@@ -295,6 +308,23 @@ fun RowChart(
                         gridEnabled = gridProperties.enabled,
                         yPadding = yPadding
                     )
+
+                    val drawZeroLine = {
+                        drawLine(
+                            brush = zeroLineProperties.color,
+                            start = Offset(x = zeroX.toFloat(), y = yPadding),
+                            end = Offset(
+                                x = zeroX.toFloat(),
+                                y = yPadding + barAreaHeight * zeroLineAnimation.value
+                            ),
+                            pathEffect = zeroLineProperties.style.pathEffect,
+                            strokeWidth = zeroLineProperties.thickness.toPx()
+                        )
+                    }
+                    if (zeroLineProperties.enabled && zeroLineProperties.zType == ZeroLineProperties.ZType.Under) {
+                        drawZeroLine()
+                    }
+
                     data.forEachIndexed { dataIndex, bars ->
                         bars.values.forEachIndexed { barIndex, bar ->
                             if (bar.value != 0.0) {
@@ -353,6 +383,9 @@ fun RowChart(
                                 )
                             }
                         }
+                    }
+                    if (zeroLineProperties.enabled && zeroLineProperties.zType == ZeroLineProperties.ZType.Above) {
+                        drawZeroLine()
                     }
                     if (indicatorProperties.enabled) {
                         indicators.reversed().forEachIndexed { index, indicator ->


### PR DESCRIPTION
## Summary

- Add `zeroLineProperties` parameter to `ColumnChart` and `RowChart`, reusing the existing `ZeroLineProperties` model from `LineChart`
- Draw an animated horizontal zero line in column charts and a vertical zero line in row charts when negative values are supported
- Support `ZType.Under` and `ZType.Above` layering, matching `LineChart` behavior
- Enable zero line in negative-value demo samples (`ColumnSample3`, `RowSample3`)
- Document usage in column and row chart guides

Closes #161

## Commits

1. `feat(ColumnChart): add ZeroLineProperties parameter and drawing`
2. `feat(RowChart): add ZeroLineProperties parameter and drawing`
3. `demo: enable zero line in negative-value chart samples`
4. `docs: document ZeroLineProperties for column and row charts`

## Test plan

- [x] `:compose-charts:compileDebugKotlinAndroid` builds successfully
- [x] `:app:compileDebugKotlinAndroid` builds successfully
- [ ] Run app and open ColumnSample3 — zero line visible at y=0 between positive/negative bars
- [ ] Run app and open RowSample3 — vertical zero line visible at x=0
- [ ] Verify zero line animates on first render
- [ ] Verify existing charts without `zeroLineProperties` are unchanged (default disabled)