### PR TITLE
feat(PieChart): add startDegree parameter

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/PieChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/PieChart.kt
@@ -45,6 +45,7 @@ import kotlin.random.Random
 fun PieChart(
     modifier: Modifier = Modifier,
     data: List<Pie>,
+    startDegree: Float = 0f,
     spaceDegree: Float = 0f,
     onPieClick: (Pie) -> Unit = {},
     selectedScale: Float = 1.1f,
@@ -161,15 +162,17 @@ fun PieChart(
                 }
         }
         Canvas(modifier = modifier
-            .pointerInput(Unit) {
+            .pointerInput(pieces.size, startDegree, data) {
                 detectTapGestures { offset ->
                     val angleInDegree = getAngleInDegree(
                         touchTapOffset = offset,
                         pieceOffset = pieChartCenter
                     )
+                    val normalizedAngle =
+                        ((angleInDegree - startDegree) % 360f + 360f) % 360f
 
                     pieces.firstOrNull { piece ->
-                        angleInDegree in piece.startFromDegree..piece.endToDegree &&
+                        normalizedAngle in piece.startFromDegree..piece.endToDegree &&
                                 isInsideCircle(offset, pieChartCenter, piece.radius)
                     }
                         ?.let {
@@ -224,15 +227,16 @@ fun PieChart(
                     }
                 } else {
                     val beforeItems = data.filterIndexed { filterIndex, chart -> filterIndex < index }
-                    val startFromDegree = beforeItems.sumOf { (it.data * 360) / total }
+                    val sliceStart = beforeItems.sumOf { (it.data * 360) / total }.toFloat()
 
                     val arcRect = Rect(
                         center = center,
                         radius = radius * detail.scale.value
                     )
 
-                    val arcStart = startFromDegree.toFloat() + detail.space.value
+                    val arcStart = sliceStart + detail.space.value + startDegree
                     val arcSweep = degree.toFloat() - ((detail.space.value * 2) + spaceDegree)
+                    val sliceEnd = sliceStart + detail.space.value + arcSweep
 
                     val piecePath = Path().apply {
                         arcTo(arcRect, arcStart, arcSweep, true)
@@ -260,8 +264,8 @@ fun PieChart(
                         PiePiece(
                             id = detail.id,
                             radius = radius * detail.scale.value,
-                            startFromDegree = arcStart,
-                            endToDegree = if (arcStart + arcSweep >= 360f) 360f else arcStart + arcSweep,
+                            startFromDegree = sliceStart + detail.space.value,
+                            endToDegree = if (sliceEnd >= 360f) 360f else sliceEnd,
                         )
                     )
                     piecePath


### PR DESCRIPTION
## Summary

- Add `startDegree` parameter to `PieChart` (default `0f` = first slice at 3 o'clock)
- Apply offset to arc drawing; use `-90f` to start at 12 o'clock (top)
- Normalize tap angles for accurate slice click detection after rotation
- Update `PieSample` demo and pie chart documentation

Closes #166

## Commits

1. `feat(PieChart): add startDegree parameter for arc layout`
2. `demo: start PieSample at 12 o'clock with startDegree -90f`
3. `docs: document PieChart startDegree parameter`

## Test plan

- [x] `:compose-charts:compileDebugKotlinAndroid` builds successfully
- [x] `:app:compileDebugKotlinAndroid` builds successfully
- [ ] Run app — first pie slice starts at top (12 o'clock) in PieSample
- [ ] Tap each slice — correct segment is selected
- [ ] Default `startDegree = 0f` behavior unchanged for existing callers