### PR TITLE
fix(LineChart): correct PointMode valueIndex and dot alignment

### DIFF
--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -81,6 +81,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.math.abs
 
 private data class Popup(
     val properties: PopupProperties,
@@ -277,32 +278,42 @@ fun LineChart(
                 val showOnPointsThreshold =
                     ((properties.mode as? PopupProperties.Mode.PointMode)?.threshold
                         ?: 0.dp).toPx()
-                val pointX = pathData.xPositions.find {
-                    it in positionX - showOnPointsThreshold..positionX + showOnPointsThreshold
+                val pointIndex = if (properties.mode is PopupProperties.Mode.PointMode && !isSingleValue) {
+                    findNearestValueIndex(
+                        x = positionX,
+                        pathData = pathData,
+                        valuesCount = line.values.size,
+                        threshold = showOnPointsThreshold
+                    )
+                } else {
+                    null
                 }
 
-                if (properties.mode !is PopupProperties.Mode.PointMode || pointX != null || isSingleValue) {
-                    val relevantX =
-                        if (properties.mode is PopupProperties.Mode.PointMode) (pointX?.toFloat()
-                            ?: 0f) else positionX
-                    val fraction = (relevantX / size.width)
+                if (properties.mode !is PopupProperties.Mode.PointMode || pointIndex != null || isSingleValue) {
+                    val relevantX = when {
+                        isSingleValue -> 0f
+                        pointIndex != null -> pathData.xPositions[pointIndex].toFloat()
+                        else -> positionX
+                    }
+                    val fraction = relevantX / size.width
 
-                    val valueIndex = if(isSingleValue){
-                        0
-                    }else{
-                        calculateValueIndex(
+                    val valueIndex = when {
+                        isSingleValue -> 0
+                        pointIndex != null -> pointIndex
+                        else -> calculateValueIndex(
                             fraction = fraction.toDouble(),
                             values = line.values,
-                            pathData = pathData
+                            pathData = pathData,
+                            chartWidth = size.width.toFloat()
                         )
                     }
 
-                    val popupValue = if(isSingleValue){
+                    val popupValue = if (isSingleValue) {
                         Value(
                             calculatedValue = line.values.first(),
                             offset = Offset(
                                 x = 0f,
-                                y = size.height-calculateOffset(
+                                y = size.height - calculateOffset(
                                     maxValue = maxValue,
                                     minValue = minValue,
                                     value = line.values.first().toFloat(),
@@ -310,7 +321,21 @@ fun LineChart(
                                 ).toFloat()
                             )
                         )
-                    }else{
+                    } else if (pointIndex != null && properties.mode is PopupProperties.Mode.PointMode) {
+                        val value = line.values[pointIndex]
+                        Value(
+                            calculatedValue = value,
+                            offset = Offset(
+                                x = pathData.xPositions[pointIndex].toFloat(),
+                                y = size.height - calculateOffset(
+                                    maxValue = computedMaxValue,
+                                    minValue = minValue,
+                                    total = size.height.toFloat(),
+                                    value = value.toFloat()
+                                ).toFloat()
+                            )
+                        )
+                    } else {
                         getPopupValue(
                             points = line.values,
                             fraction = fraction.toDouble(),
@@ -622,16 +647,36 @@ private fun Indicators(
     }
 }
 
+private fun findNearestValueIndex(
+    x: Float,
+    pathData: PathData,
+    valuesCount: Int,
+    threshold: Float? = null,
+): Int? {
+    if (valuesCount <= 0) return null
+    val lastIndex = valuesCount - 1
+    val nearestIndex = pathData.xPositions.indices
+        .filter { it <= lastIndex }
+        .minByOrNull { abs(pathData.xPositions[it] - x) }
+        ?: return null
+    if (threshold != null && abs(pathData.xPositions[nearestIndex] - x) > threshold) {
+        return null
+    }
+    return nearestIndex
+}
+
 private fun calculateValueIndex(
     fraction: Double,
     values: List<Double>,
-    pathData: PathData
+    pathData: PathData,
+    chartWidth: Float,
 ): Int {
-    val xPosition = (fraction * pathData.path.getBounds().width).toFloat()
-    val closestXIndex = pathData.xPositions.indexOfFirst { x ->
-        x >= xPosition
-    }
-    return if (closestXIndex >= 0) closestXIndex else values.size - 1
+    if (values.size <= 1) return 0
+    return findNearestValueIndex(
+        x = (fraction * chartWidth).toFloat(),
+        pathData = pathData,
+        valuesCount = values.size
+    ) ?: values.lastIndex
 }
 
 private fun DrawScope.drawPopup(

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -584,6 +584,7 @@ fun LineChart(
                                 pathMeasure = pathMeasure,
                                 scope = scope,
                                 size = size,
+                                xPositions = pathData.xPositions,
                                 startIndex = pathData.startIndex,
                                 endIndex = pathData.endIndex
                             )
@@ -798,6 +799,7 @@ private fun DrawScope.drawDots(
     pathMeasure: PathMeasure,
     scope: CoroutineScope,
     size: Size? = null,
+    xPositions: List<Double>,
     startIndex: Int,
     endIndex: Int,
 ) {
@@ -812,11 +814,11 @@ private fun DrawScope.drawDots(
             properties.confirmDraw(DotProperties.Dot(value.dataIndex, valueIndex, value.value.toDouble())) &&
             valueIndex in startIndex..endIndex
         ) {
+            val dotX = xPositions.getOrElse(valueIndex) {
+                if (dataPoints.size <= 1) 0.0 else valueIndex * _size.width.toDouble() / (dataPoints.size - 1)
+            }.toFloat()
             val dotOffset = Offset(
-                x = _size.width.spaceBetween(
-                    itemCount = dataPoints.count(),
-                    index = valueIndex
-                ),
+                x = dotX,
                 y = (_size.height - calculateOffset(
                     maxValue = maxValue.toDouble(),
                     minValue = minValue.toDouble(),

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/LineChart.kt
@@ -814,9 +814,13 @@ private fun DrawScope.drawDots(
             properties.confirmDraw(DotProperties.Dot(value.dataIndex, valueIndex, value.value.toDouble())) &&
             valueIndex in startIndex..endIndex
         ) {
-            val dotX = xPositions.getOrElse(valueIndex) {
-                if (dataPoints.size <= 1) 0.0 else valueIndex * _size.width.toDouble() / (dataPoints.size - 1)
-            }.toFloat()
+            val dotX = if (dataPoints.size == 1) {
+                0f
+            } else {
+                xPositions.getOrElse(valueIndex) {
+                    valueIndex * _size.width.toDouble() / (dataPoints.size - 1)
+                }.toFloat()
+            }
             val dotOffset = Offset(
                 x = dotX,
                 y = (_size.height - calculateOffset(

--- a/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/line_chart/Line.kt
+++ b/compose-charts/src/commonMain/kotlin/ir/ehsannarmani/compose_charts/extensions/line_chart/Line.kt
@@ -61,6 +61,10 @@ internal fun DrawScope.getLinePath(
 
         xPositions.add(x1.toDouble())
     }
-    xPositions.add(_size.width.toDouble())
+    if (dataPoints.size == 1) {
+        xPositions.add(0.0)
+    } else {
+        xPositions.add(_size.width.toDouble())
+    }
     return PathData(path = path, xPositions = xPositions,startIndex,endIndex)
 }


### PR DESCRIPTION
## Summary

- Fix incorrect `valueIndex` in `PopupProperties.Mode.PointMode` for large datasets (reported with 30 data points)
- Replace `indexOfFirst { x >= xPosition }` with nearest-neighbor lookup on `pathData.xPositions` to avoid off-by-one errors from floating-point rounding
- Snap PointMode popups to the exact data point value and position instead of interpolating along the line
- Align dot x coordinates with line path `xPositions` for consistent marker placement

Fixes #129

## Root cause

`calculateValueIndex` mapped touch position using `indexOfFirst { x >= xPosition }` against path bounds width. Small floating-point differences pushed the index to the next data point (e.g. index 4 instead of 3). PointMode also reused interpolated popup values instead of the tapped point.

## Commits

1. `fix(LineChart): correct PointMode valueIndex with nearest data point`
2. `fix(LineChart): align dot x positions with line path xPositions`

## Test plan

- [x] `:compose-charts:compileDebugKotlinAndroid` builds successfully
- [x] `:app:compileDebugKotlinAndroid` builds successfully
- [ ] LineChart with 30 points + `PopupProperties.Mode.PointMode()` — tap each dot, `valueIndex` matches label index
- [ ] Same chart with `Mode.Normal` — behavior unchanged
- [ ] Chart with dots enabled — markers align with line vertices on dense datasets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LineChart popups during tap and drag interactions by selecting the nearest data point more accurately.
  * Corrected popup positioning and value display for single-point and point-based charts.
  * Fixed dot placement so markers align consistently with plotted data points.
  * Improved rendering and interaction behavior for charts containing only one data point.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->